### PR TITLE
alt+x show commands palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,17 +176,11 @@
             },
             {
                 "key": "alt+x",
-                "command": "emacs.M-x",
-                "when": "editorTextFocus"
+                "command": "workbench.action.showCommands"
             },
             {
                 "key": "ctrl+x",
                 "command": "emacs.C-x",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "alt+x",
-                "command": "emacs.M-x",
                 "when": "editorTextFocus"
             },
             {


### PR DESCRIPTION
emacs.M-x was doing nothing, now change it to show commands palette
